### PR TITLE
Introduce a FavoriteService wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### New features
 
+- New `\WizaplaceFrontBundle\Service\FavoriteService` which decorates the SDK's `FavoriteService` with a request-scoped cache
+
 ### Bugfixes
 
 </details>

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -99,6 +99,8 @@ services:
         public: true
     Wizaplace\SDK\Translation\TranslationService:
         public: true
+    WizaplaceFrontBundle\Service\FavoriteService:
+        public: true
     WizaplaceFrontBundle\Twig\AppExtension:
         arguments:
             $cache: '@cache.app'

--- a/src/Service/FavoriteService.php
+++ b/src/Service/FavoriteService.php
@@ -14,6 +14,10 @@ use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
 use Wizaplace\SDK\Catalog\DeclinationId;
 use Wizaplace\SDK\Catalog\DeclinationSummary;
 
+/**
+ * Decorates {@see \Wizaplace\SDK\Favorite\FavoriteService}.
+ * Adds a request-scoped cache.
+ */
 class FavoriteService implements LogoutHandlerInterface
 {
     /** @var \Wizaplace\SDK\Favorite\FavoriteService */

--- a/src/Service/FavoriteService.php
+++ b/src/Service/FavoriteService.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @copyright Copyright (c) Wizacha
+ * @license Proprietary
+ */
+declare(strict_types=1);
+
+namespace WizaplaceFrontBundle\Service;
+
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Wizaplace\SDK\Catalog\DeclinationSummary;
+
+class FavoriteService
+{
+    /** @var \Wizaplace\SDK\Favorite\FavoriteService */
+    private $baseService;
+
+    /** @var SessionInterface */
+    private $session;
+
+    private const FAVORITES_IDS_CACHE_SESSION_KEY = self::class.'::FAVORITES_IDS_CACHE_SESSION_KEY';
+
+    public function __construct(\Wizaplace\SDK\Favorite\FavoriteService $baseService, SessionInterface $session)
+    {
+        $this->baseService = $baseService;
+        $this->session = $session;
+    }
+
+    /**
+     * @see \Wizaplace\SDK\Favorite\FavoriteService::getAll
+     * @return DeclinationSummary[]
+     */
+    public function getAll() : array
+    {
+        $result = $this->baseService->getAll();
+
+        // re-build cache entirely
+        $cache = array_reverse(array_map(function (DeclinationSummary $declination): string {
+            return $declination->getId();
+        }, $result));
+        $this->session->set(self::FAVORITES_IDS_CACHE_SESSION_KEY, $cache);
+    }
+
+    /**
+     * @see \Wizaplace\SDK\Favorite\FavoriteService::isInFavorites
+     */
+    public function isInFavorites(string $declinationId) : bool
+    {
+        $cache = $this->session->get(self::FAVORITES_IDS_CACHE_SESSION_KEY, null);
+        if (!is_array($cache)) {
+            $this->getAll();
+        }
+        $cache = $this->session->get(self::FAVORITES_IDS_CACHE_SESSION_KEY, []);
+
+        return isset($cache[$declinationId]);
+    }
+
+    /**
+     * @see \Wizaplace\SDK\Favorite\FavoriteService::addDeclinationToUserFavorites
+     */
+    public function addDeclinationToUserFavorites(string $declinationId) : void
+    {
+        $this->baseService->addDeclinationToUserFavorites($declinationId);
+
+        // add ID to cache
+        $cache = $this->session->get(self::FAVORITES_IDS_CACHE_SESSION_KEY, null);
+        $cache[$declinationId] = true;
+        $this->session->set(self::FAVORITES_IDS_CACHE_SESSION_KEY, $cache);
+    }
+
+    /**
+     * @see \Wizaplace\SDK\Favorite\FavoriteService::removeDeclinationToUserFavorites
+     */
+    public function removeDeclinationToUserFavorites(string $declinationId) : void
+    {
+        $this->baseService->removeDeclinationToUserFavorites($declinationId);
+
+        // remove ID from cache
+        $cache = $this->session->get(self::FAVORITES_IDS_CACHE_SESSION_KEY, null);
+        unset($cache[$declinationId]);
+        $this->session->set(self::FAVORITES_IDS_CACHE_SESSION_KEY, $cache);
+    }
+}

--- a/src/Service/FavoriteService.php
+++ b/src/Service/FavoriteService.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
+use Wizaplace\SDK\Catalog\DeclinationId;
 use Wizaplace\SDK\Catalog\DeclinationSummary;
 
 class FavoriteService implements LogoutHandlerInterface
@@ -36,7 +37,7 @@ class FavoriteService implements LogoutHandlerInterface
 
         // re-build cache entirely
         $this->favoritesIdsCache = array_reverse(array_map(function (DeclinationSummary $declination): string {
-            return $declination->getId();
+            return (string) $declination->getId();
         }, $result));
 
         return $result;
@@ -45,35 +46,35 @@ class FavoriteService implements LogoutHandlerInterface
     /**
      * @see \Wizaplace\SDK\Favorite\FavoriteService::isInFavorites
      */
-    public function isInFavorites(string $declinationId) : bool
+    public function isInFavorites(DeclinationId $declinationId) : bool
     {
         if (!is_array($this->favoritesIdsCache)) {
             $this->getAll();
         }
 
-        return isset($this->favoritesIdsCache[$declinationId]);
+        return isset($this->favoritesIdsCache[(string) $declinationId]);
     }
 
     /**
      * @see \Wizaplace\SDK\Favorite\FavoriteService::addDeclinationToUserFavorites
      */
-    public function addDeclinationToUserFavorites(string $declinationId) : void
+    public function addDeclinationToUserFavorites(DeclinationId $declinationId) : void
     {
         $this->baseService->addDeclinationToUserFavorites($declinationId);
 
         // add ID to cache
-        $this->favoritesIdsCache[$declinationId] = true;
+        $this->favoritesIdsCache[(string) $declinationId] = true;
     }
 
     /**
      * @see \Wizaplace\SDK\Favorite\FavoriteService::removeDeclinationToUserFavorites
      */
-    public function removeDeclinationToUserFavorites(string $declinationId) : void
+    public function removeDeclinationToUserFavorites(DeclinationId $declinationId) : void
     {
         $this->baseService->removeDeclinationToUserFavorites($declinationId);
 
         // remove ID from cache
-        unset($this->favoritesIdsCache[$declinationId]);
+        unset($this->favoritesIdsCache[(string) $declinationId]);
     }
 
     /**

--- a/src/Service/FavoriteService.php
+++ b/src/Service/FavoriteService.php
@@ -39,6 +39,8 @@ class FavoriteService
             return $declination->getId();
         }, $result));
         $this->session->set(self::FAVORITES_IDS_CACHE_SESSION_KEY, $cache);
+
+        return $result;
     }
 
     /**

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -16,6 +16,7 @@ use Wizaplace\SDK\Image\ImageService;
 use Wizaplace\SDK\User\UserService;
 use WizaplaceFrontBundle\Service\AttributeVariantUrlGenerator;
 use WizaplaceFrontBundle\Service\BasketService;
+use WizaplaceFrontBundle\Service\FavoriteService;
 use WizaplaceFrontBundle\Service\ProductUrlGenerator;
 
 class AppExtension extends \Twig_Extension
@@ -42,6 +43,8 @@ class AppExtension extends \Twig_Extension
     private $productUrlGenerator;
     /** @var AttributeVariantUrlGenerator */
     private $attributeVariantUrlGenerator;
+    /** @var FavoriteService */
+    private $favoriteService;
 
     public function __construct(
         CatalogService $catalogService,
@@ -54,7 +57,8 @@ class AppExtension extends \Twig_Extension
         string $recaptchaKey,
         Packages $assets,
         ProductUrlGenerator $productUrlGenerator,
-        AttributeVariantUrlGenerator $attributeVariantUrlGenerator
+        AttributeVariantUrlGenerator $attributeVariantUrlGenerator,
+        FavoriteService $favoriteService
     ) {
         $this->catalogService = $catalogService;
         $this->session = $session;
@@ -67,6 +71,7 @@ class AppExtension extends \Twig_Extension
         $this->assets = $assets;
         $this->productUrlGenerator = $productUrlGenerator;
         $this->attributeVariantUrlGenerator = $attributeVariantUrlGenerator;
+        $this->favoriteService = $favoriteService;
     }
 
     public function getFunctions()
@@ -78,6 +83,7 @@ class AppExtension extends \Twig_Extension
             new \Twig_SimpleFunction('basket', [$this->basketService, 'getBasket']),
             new \Twig_SimpleFunction('recaptchaKey', [$this, 'getRecaptchaKey']),
             new \Twig_SimpleFunction('menus', [$this->cmsService, 'getAllMenus']),
+            new \Twig_SimpleFunction('isInFavorites', [$this->favoriteService, 'isInFavorites']),
         ];
     }
 

--- a/tests/Service/FavoriteServiceTest.php
+++ b/tests/Service/FavoriteServiceTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @copyright Copyright (c) Wizacha
+ * @license Proprietary
+ */
+declare(strict_types=1);
+
+namespace WizaplaceFrontBundle\Tests\Service;
+
+use Wizaplace\SDK\ApiClient;
+use WizaplaceFrontBundle\Service\FavoriteService;
+use WizaplaceFrontBundle\Tests\BundleTestCase;
+
+class FavoriteServiceTest extends BundleTestCase
+{
+    public function testIsInFavorites()
+    {
+        $container = self::$kernel->getContainer();
+        $container->get(ApiClient::class)->authenticate('user@wizaplace.com', 'password');
+
+        self::assertFalse($container->get(FavoriteService::class)->isInFavorites('1_0'));
+
+        $container->get(FavoriteService::class)->addDeclinationToUserFavorites('1_0');
+
+        self::assertTrue($container->get(FavoriteService::class)->isInFavorites('1_0'));
+
+        $container->get(FavoriteService::class)->removeDeclinationToUserFavorites('1_0');
+
+        self::assertFalse($container->get(FavoriteService::class)->isInFavorites('1_0'));
+    }
+}

--- a/tests/Service/FavoriteServiceTest.php
+++ b/tests/Service/FavoriteServiceTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace WizaplaceFrontBundle\Tests\Service;
 
 use Wizaplace\SDK\ApiClient;
+use Wizaplace\SDK\Catalog\DeclinationId;
 use WizaplaceFrontBundle\Service\FavoriteService;
 use WizaplaceFrontBundle\Tests\BundleTestCase;
 
@@ -18,14 +19,14 @@ class FavoriteServiceTest extends BundleTestCase
         $container = self::$kernel->getContainer();
         $container->get(ApiClient::class)->authenticate('user@wizaplace.com', 'password');
 
-        self::assertFalse($container->get(FavoriteService::class)->isInFavorites('1_0'));
+        self::assertFalse($container->get(FavoriteService::class)->isInFavorites(new DeclinationId('1_0')));
 
-        $container->get(FavoriteService::class)->addDeclinationToUserFavorites('1_0');
+        $container->get(FavoriteService::class)->addDeclinationToUserFavorites(new DeclinationId('1_0'));
 
-        self::assertTrue($container->get(FavoriteService::class)->isInFavorites('1_0'));
+        self::assertTrue($container->get(FavoriteService::class)->isInFavorites(new DeclinationId('1_0')));
 
-        $container->get(FavoriteService::class)->removeDeclinationToUserFavorites('1_0');
+        $container->get(FavoriteService::class)->removeDeclinationToUserFavorites(new DeclinationId('1_0'));
 
-        self::assertFalse($container->get(FavoriteService::class)->isInFavorites('1_0'));
+        self::assertFalse($container->get(FavoriteService::class)->isInFavorites(new DeclinationId('1_0')));
     }
 }

--- a/tests/Service/FavoriteServiceTest/testIsInFavorites_K7.yml
+++ b/tests/Service/FavoriteServiceTest/testIsInFavorites_K7.yml
@@ -1,0 +1,92 @@
+
+-
+    request:
+        method: GET
+        url: 'http://wizaplace.loc/api/v1/users/authenticate'
+        headers:
+            Authorization: 'Basic dXNlckB3aXphcGxhY2UuY29tOnBhc3N3b3Jk'
+            Host: wizaplace.loc
+            VCR-index: '0'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Date: 'Wed, 08 Nov 2017 15:17:16 GMT'
+            Server: 'Apache/2.4.10 (Debian)'
+            Cache-Control: 'no-cache, private'
+            Content-Language: fr
+            X-Debug-Token: 24bc11
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/24bc11'
+            Content-Length: '60'
+            Content-Type: application/json
+        body: '{"id":3,"apiKey":"SV0yBMFQTaNdySZjGk0omkkUvMHFw1G6Li7i307q"}'
+-
+    request:
+        method: GET
+        url: 'http://wizaplace.loc/api/v1/user/favorites/declinations'
+        headers:
+            Host: wizaplace.loc
+            Authorization: 'token SV0yBMFQTaNdySZjGk0omkkUvMHFw1G6Li7i307q'
+            VCR-index: '1'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Date: 'Wed, 08 Nov 2017 15:17:17 GMT'
+            Server: 'Apache/2.4.10 (Debian)'
+            Cache-Control: 'no-cache, private'
+            Content-Language: fr
+            X-Debug-Token: f8ae4a
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/f8ae4a'
+            Content-Length: '50'
+            Content-Type: application/json
+        body: '{"total":0,"count":0,"_embedded":{"favorites":[]}}'
+-
+    request:
+        method: POST
+        url: 'http://wizaplace.loc/api/v1/user/favorites/declinations/1_0'
+        headers:
+            Host: wizaplace.loc
+            Authorization: 'token SV0yBMFQTaNdySZjGk0omkkUvMHFw1G6Li7i307q'
+            VCR-index: '2'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            Date: 'Wed, 08 Nov 2017 15:17:17 GMT'
+            Server: 'Apache/2.4.10 (Debian)'
+            Cache-Control: 'no-cache, private'
+            Content-Language: fr
+            X-Debug-Token: 4635ff
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/4635ff'
+            Content-Length: '2'
+            Content-Type: application/json
+        body: '""'
+-
+    request:
+        method: DELETE
+        url: 'http://wizaplace.loc/api/v1/user/favorites/declinations/1_0'
+        headers:
+            Host: wizaplace.loc
+            Authorization: 'token SV0yBMFQTaNdySZjGk0omkkUvMHFw1G6Li7i307q'
+            VCR-index: '3'
+    response:
+        status:
+            http_version: '1.1'
+            code: '204'
+            message: 'No Content'
+        headers:
+            Date: 'Wed, 08 Nov 2017 15:17:17 GMT'
+            Server: 'Apache/2.4.10 (Debian)'
+            Cache-Control: 'no-cache, private'
+            Content-Language: fr
+            X-Debug-Token: 7650d8
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/7650d8'
+            Content-Length: '0'
+            Content-Type: 'text/html; charset=UTF-8'


### PR DESCRIPTION
User story : on veut pouvoir savoir dans les listings si certains produits sont en favoris.

Problème : actuellement chaque appel à `isInFavorites` fait une requète à l'API. Quand on a des listings avec des dizaines de produits, ce n'est pas viable.

Solution proposée : utiliser `getAll` pour obtenir tous les IDs des favoris en un seul appel, et garder ca en cache