### PR TITLE
🎄 Add \WizaplaceFrontBundle\Command\WarmCategoryTreeCommand 🎄

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
  - Add cache on `getCategoryTree` which avoids loading the tree several times during a single request
  - Set `%locales%` default value to `%kernel.default_locale%`, facilitating the transition from version 0.2.* to >=0.3.0
+ - Add `\WizaplaceFrontBundle\Command\WarmCategoryTreeCommand`
 
 ## 0.3.1
 

--- a/src/Command/WarmCategoryTreeCommand.php
+++ b/src/Command/WarmCategoryTreeCommand.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @copyright Copyright (c) Wizacha
+ * @license Proprietary
+ */
+declare(strict_types=1);
+
+namespace WizaplaceFrontBundle\Command;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\Promise;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Wizaplace\SDK\ApiClient;
+use Wizaplace\SDK\Catalog\CatalogService;
+
+class WarmCategoryTreeCommand extends Command
+{
+    /**
+     * @var CatalogService
+     */
+    private $catalogService;
+
+    public function __construct(Client $httpClient)
+    {
+        parent::__construct();
+        $httpClient = $this->wrapClient($httpClient);
+        $this->catalogService = new CatalogService(new ApiClient($httpClient));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->catalogService->getCategoryTree();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('wizaplace:warm:categoryTree')
+            ->setDescription('Warm-up the category tree cache.');
+    }
+
+    private function wrapClient(Client $httpClient): Client
+    {
+        $config = $httpClient->getConfig();
+        $newHandler = new HandlerStack($config['handler']);
+        $newHandler->push(static function (callable $handler): callable {
+            return function (RequestInterface $request, array $options) use (&$handler): Promise {
+                $request = $request->withHeader('Cache-Control', 'no-cache');
+
+                return $handler($request, $options);
+            };
+        });
+        $config['handler'] = $newHandler;
+
+        return new Client($config);
+    }
+}


### PR DESCRIPTION
Pour que le categoryTree puisse passer l'hiver, voilà une petite comande Symfony qui permet de le réchauffer. Il suffit de faire tourner un cron qui lance cette commande à interval < 15 minutes et il sera toujours chaud.

## Checklist

- [x] Changelog updated
