### PR TITLE
Fix deprecated get of private translation services in tests

### DIFF
--- a/tests/Command/PushAndPullTranslationsCommandTest.php
+++ b/tests/Command/PushAndPullTranslationsCommandTest.php
@@ -31,7 +31,7 @@ class PushAndPullTranslationsCommandTest extends BundleTestCase
 
         $application->add(new PushTranslationsCommand(
             $translatorBag,
-            static::$kernel->getContainer()->get('translation.dumper.xliff'),
+            static::$kernel->getContainer()->get('test.translation.dumper.xliff'),
             static::$kernel->getContainer()->get(TranslationService::class),
             static::$kernel->getContainer()->get(AuthenticationService::class),
             [ 'fr' ],
@@ -57,7 +57,7 @@ class PushAndPullTranslationsCommandTest extends BundleTestCase
         $commandTester->execute(['command'  => $pullCommand->getName()]);
 
         $this->assertFileExists($translationsDir.'/messages.fr.xliff');
-        $pulledCatalog = static::$kernel->getContainer()->get('translation.loader.xliff')->load($translationsDir.'/messages.fr.xliff', 'fr');
+        $pulledCatalog = static::$kernel->getContainer()->get('test.translation.loader.xliff')->load($translationsDir.'/messages.fr.xliff', 'fr');
         $this->assertCount(0, $pulledCatalog->all());
     }
 
@@ -106,7 +106,7 @@ class PushAndPullTranslationsCommandTest extends BundleTestCase
         $commandTester->execute(['command'  => $pullCommand->getName()]);
 
         $this->assertFileExists($translationsDir.'/messages.fr.xliff');
-        $pulledFrCatalog = static::$kernel->getContainer()->get('translation.loader.xliff')->load($translationsDir.'/messages.fr.xliff', 'fr');
+        $pulledFrCatalog = static::$kernel->getContainer()->get('test.translation.loader.xliff')->load($translationsDir.'/messages.fr.xliff', 'fr');
         $this->assertSame([
             'messages' =>
             [
@@ -116,7 +116,7 @@ class PushAndPullTranslationsCommandTest extends BundleTestCase
         ], $pulledFrCatalog->all());
 
         $this->assertFileExists($translationsDir.'/messages.en.xliff');
-        $pulledEnCatalog = static::$kernel->getContainer()->get('translation.loader.xliff')->load($translationsDir.'/messages.en.xliff', 'en');
+        $pulledEnCatalog = static::$kernel->getContainer()->get('test.translation.loader.xliff')->load($translationsDir.'/messages.en.xliff', 'en');
         $this->assertSame([
             'messages' =>
             [

--- a/tests/Command/PushAndPullTranslationsCommandTest.php
+++ b/tests/Command/PushAndPullTranslationsCommandTest.php
@@ -80,7 +80,7 @@ class PushAndPullTranslationsCommandTest extends BundleTestCase
 
         $application->add(new PushTranslationsCommand(
             $translatorBag,
-            static::$kernel->getContainer()->get('translation.dumper.xliff'),
+            static::$kernel->getContainer()->get('test.translation.dumper.xliff'),
             static::$kernel->getContainer()->get(TranslationService::class),
             static::$kernel->getContainer()->get(AuthenticationService::class),
             [ 'fr', 'en' ],

--- a/tests/TestEnv/config.yml
+++ b/tests/TestEnv/config.yml
@@ -78,3 +78,5 @@ services:
         alias: 'WizaplaceFrontBundle\Service\SitemapGenerator'
         public: true
     test.WizaplaceFrontBundle\Twig\AppExtension: '@WizaplaceFrontBundle\Twig\AppExtension'
+    test.translation.dumper.xliff: '@translation.dumper.xliff'
+    test.translation.loader.xliff: '@translation.loader.xliff'


### PR DESCRIPTION
```
Remaining deprecation notices (5)

The "translation.loader.xliff" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead: 3x
    2x in PushAndPullTranslationsCommandTest::testExecuteWith2Locales from WizaplaceFrontBundle\Tests\Command
    1x in PushAndPullTranslationsCommandTest::testExecuteWithEmptyCatalog from WizaplaceFrontBundle\Tests\Command

The "translation.dumper.xliff" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead: 2x
    1x in PushAndPullTranslationsCommandTest::testExecuteWithEmptyCatalog from WizaplaceFrontBundle\Tests\Command
    1x in PushAndPullTranslationsCommandTest::testExecuteWith2Locales from WizaplaceFrontBundle\Tests\Command

make: *** [test-phpunit] Error 1
```