### PR TITLE
remove specific par of the cache during the pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 <details>
 <summary>Unreleased</summary>
 
+### New features
+
+ - Improve translations pull
+
 ### BREAKING CHANGES
 
 ### Bugfixes

--- a/src/Command/PullTranslationsCommand.php
+++ b/src/Command/PullTranslationsCommand.php
@@ -95,6 +95,9 @@ class PullTranslationsCommand extends Command
             return;
         }
 
+        if (!file_exists($this->cacheDir)) {
+            return;
+        }
         $finder = new Finder();
         $finder
             ->files()

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -26,7 +26,7 @@ services:
         arguments:
             $locales: '%locales%'
             $translationsDir: "%kernel.project_dir%/var/translations"
-            $cacheDir: "%kernel.cache_dir/translations%"
+            $cacheDir: "%kernel.cache_dir%/translations"
         public: true
     WizaplaceFrontBundle\Service\AuthenticationService:
         public: true

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -26,6 +26,7 @@ services:
         arguments:
             $locales: '%locales%'
             $translationsDir: "%kernel.project_dir%/var/translations"
+            $cacheDir: "%kernel.cache_dir/translations%"
         public: true
     WizaplaceFrontBundle\Service\AuthenticationService:
         public: true

--- a/tests/Command/PushAndPullTranslationsCommandTest.php
+++ b/tests/Command/PushAndPullTranslationsCommandTest.php
@@ -39,11 +39,13 @@ class PushAndPullTranslationsCommandTest extends BundleTestCase
             static::$kernel->getContainer()->getParameter('wizaplace.system_user_password')
         ));
         $translationsDir = dirname(stream_get_meta_data(tmpfile())['uri']);
+        $cacheDir = static::$kernel->getCacheDir().'/translations';
         $application->add(new PullTranslationsCommand(
             static::$kernel->getContainer()->get(TranslationService::class),
             static::$kernel->getContainer()->get(AuthenticationService::class),
             [ 'fr' ],
-            $translationsDir
+            $translationsDir,
+            $cacheDir
         ));
 
         $pushCommand = $application->find('wizaplace:translations:push');
@@ -88,11 +90,13 @@ class PushAndPullTranslationsCommandTest extends BundleTestCase
             static::$kernel->getContainer()->getParameter('wizaplace.system_user_password')
         ));
         $translationsDir = dirname(stream_get_meta_data(tmpfile())['uri']);
+        $cacheDir = static::$kernel->getCacheDir().'/translations';
         $application->add(new PullTranslationsCommand(
             static::$kernel->getContainer()->get(TranslationService::class),
             static::$kernel->getContainer()->get(AuthenticationService::class),
             [ 'fr', 'en' ],
-            $translationsDir
+            $translationsDir,
+            $cacheDir
         ));
 
         $pushCommand = $application->find('wizaplace:translations:push');


### PR DESCRIPTION
Improve the translation pull process by removing only specific runtime cache when the translations content has changed.

## Checklist

- [x] Changelog updated
