### PR TITLE
Sitemap multilang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 ### New features
 
 - Handles multilang sitemap
-- Added command `wizaplace:sitemap:generate` which replaces `sitemap:generate` and uses service dependency injection instead of the container object
 
 ### BREAKING CHANGES
+
+- This bundle now depends on `kphoen/sitemap-generator` for sitemap generation instead of `kphoen/sitemap-bundle`
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### New features
 
+- Handles multilang sitemap
+- Added command `wizaplace:sitemap:generate` which replaces `sitemap:generate` and uses service dependency injection instead of the container object
+
 ### BREAKING CHANGES
 
 ### Bugfixes
@@ -23,7 +26,7 @@
 
  - Added `WizaplaceFrontBundle\Controller\OauthController`
  - Added `WizaplaceFrontBundle\Security\LoginManager`
- 
+
 ## 0.4.3
 
  - Improve translations pull (automated cache clear)

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "require-dev": {
     "bmancone/guzzle-stopwatch-middleware": "^1.0",
-    "kphoen/sitemap-bundle": "^2.0",
+    "kphoen/sitemap-generator": "^1.4",
     "lookyman/phpstan-symfony": "~0.4.1",
     "php-vcr/php-vcr": "^1.4",
     "phpstan/phpstan": "^0.9.2",
@@ -34,7 +34,7 @@
     "wizaplace/php-coding-standard": "^1.1"
   },
   "suggest": {
-    "kphoen/sitemap-bundle": "To generate sitemaps",
+    "kphoen/sitemap-generator": "To generate sitemaps",
     "jms/i18n-routing-bundle": "To vary routes per language"
   },
   "config" : {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec601aae92bceaf7983d6b0eb765193f",
+    "content-hash": "4065d073dae1a291e3c519fb82825d7d",
     "packages": [
         {
             "name": "clue/json-stream",
@@ -2457,74 +2457,17 @@
             "time": "2017-11-09T12:15:48+00:00"
         },
         {
-            "name": "kphoen/sitemap-bundle",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sitemap-php/KPhoenSitemapBundle.git",
-                "reference": "1853d178fd3ab9dd7cf1b332da95b411b78e0e12"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sitemap-php/KPhoenSitemapBundle/zipball/1853d178fd3ab9dd7cf1b332da95b411b78e0e12",
-                "reference": "1853d178fd3ab9dd7cf1b332da95b411b78e0e12",
-                "shasum": ""
-            },
-            "require": {
-                "kphoen/sitemap-generator": "^1.0",
-                "php": ">=7.0",
-                "symfony/console": "^2.8|^3.0|^4.0 ",
-                "symfony/framework-bundle": "^2.8|^3.0|^4.0 "
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.4",
-                "symfony/browser-kit": "^2.8|^3.0|^4.0 ",
-                "symfony/translation": "^2.8|^3.0|^4.0 ",
-                "symfony/validator": "^2.8|^3.0|^4.0 ",
-                "symfony/yaml": "^2.8|^3.0|^4.0 "
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "KPhoen\\SitemapBundle\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kévin Gomez",
-                    "email": "contact@kevingomez.fr",
-                    "homepage": "http://www.kevingomez.fr/"
-                }
-            ],
-            "description": "Provides a way to create/generate a sitemap using Doctrine, etc.",
-            "keywords": [
-                "Sitemap",
-                "command",
-                "seo"
-            ],
-            "time": "2017-11-25T13:29:40+00:00"
-        },
-        {
             "name": "kphoen/sitemap-generator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sitemap-php/SitemapGenerator.git",
-                "reference": "42b9f0f6bfe737546583397d30a9be3f0712d5a5"
+                "reference": "8f74f3b7fcc3ddd0b94034a87c11d2fe220c5835"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sitemap-php/SitemapGenerator/zipball/42b9f0f6bfe737546583397d30a9be3f0712d5a5",
-                "reference": "42b9f0f6bfe737546583397d30a9be3f0712d5a5",
+                "url": "https://api.github.com/repos/sitemap-php/SitemapGenerator/zipball/8f74f3b7fcc3ddd0b94034a87c11d2fe220c5835",
+                "reference": "8f74f3b7fcc3ddd0b94034a87c11d2fe220c5835",
                 "shasum": ""
             },
             "require-dev": {
@@ -2556,7 +2499,7 @@
                 "generator",
                 "seo"
             ],
-            "time": "2015-01-12T20:03:33+00:00"
+            "time": "2018-01-22T22:56:23+00:00"
         },
         {
             "name": "lookyman/phpstan-symfony",
@@ -2606,6 +2549,7 @@
                 "PHPStan",
                 "symfony"
             ],
+            "abandoned": "phpstan/phpstan-symfony",
             "time": "2018-01-18T10:20:29+00:00"
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -2546,57 +2546,6 @@
             "time": "2018-01-22T22:56:23+00:00"
         },
         {
-            "name": "lookyman/phpstan-symfony",
-            "version": "0.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/lookyman/phpstan-symfony.git",
-                "reference": "77923bea41b68e6f83783d7ed896323e1084b127"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/lookyman/phpstan-symfony/zipball/77923bea41b68e6f83783d7ed896323e1084b127",
-                "reference": "77923bea41b68e6f83783d7ed896323e1084b127",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "jakub-onderka/php-parallel-lint": "^0.9.2",
-                "lookyman/coding-standard": "0.1.0",
-                "phpstan/phpstan": "^0.9.0",
-                "phpstan/phpstan-phpunit": "^0.9.0",
-                "phpstan/phpstan-strict-rules": "^0.9.0",
-                "phpunit/phpunit": "^6.4",
-                "symfony/framework-bundle": "^4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Lookyman\\PHPStan\\Symfony\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Lukáš Unger",
-                    "email": "looky.msc@gmail.com",
-                    "homepage": "https://lookyman.net"
-                }
-            ],
-            "description": "Symfony extension for PHPStan",
-            "keywords": [
-                "PHPStan",
-                "symfony"
-            ],
-            "abandoned": "phpstan/phpstan-symfony",
-            "time": "2018-01-18T10:20:29+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
             "version": "1.7.0",
             "source": {

--- a/src/Command/GenerateSitemapCommand.php
+++ b/src/Command/GenerateSitemapCommand.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @copyright Copyright (c) Wizacha
+ * @license Proprietary
+ */
+declare(strict_types=1);
+
+namespace WizaplaceFrontBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use SitemapGenerator\Sitemap\Sitemap;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class GenerateSitemapCommand extends ContainerAwareCommand
+{
+    private $sitemap;
+    private $locales;
+
+    public function __construct(Sitemap $sitemap)
+    {
+        $this->sitemap = $sitemap;
+
+        parent::__construct();
+    }
+
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this
+            ->setDescription('Generate the sitemap')
+            ->setName('wizaplace:sitemap:generate');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->section("Generating the sitemap...");
+        $io->text($this->sitemap->build());
+        $io->success("Sitemap successfully generated!");
+    }
+}

--- a/src/Command/GenerateSitemapCommand.php
+++ b/src/Command/GenerateSitemapCommand.php
@@ -31,7 +31,7 @@ class GenerateSitemapCommand extends ContainerAwareCommand
     {
         $this
             ->setDescription('Generate the sitemap')
-            ->setName('wizaplace:sitemap:generate');
+            ->setName('sitemap:generate');
     }
 
     /**

--- a/src/Command/GenerateSitemapCommand.php
+++ b/src/Command/GenerateSitemapCommand.php
@@ -16,7 +16,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class GenerateSitemapCommand extends ContainerAwareCommand
 {
     private $sitemap;
-    private $locales;
 
     public function __construct(Sitemap $sitemap)
     {

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -28,6 +28,10 @@ services:
             $translationsDir: "%kernel.project_dir%/var/translations"
             $cacheDir: "%kernel.cache_dir%/translations"
         public: true
+    WizaplaceFrontBundle\Command\GenerateSitemapCommand:
+        arguments:
+            $locales: '%locales%'
+        public: true
     WizaplaceFrontBundle\Service\AuthenticationService:
         public: true
         arguments:

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -29,6 +29,8 @@ services:
             $cacheDir: "%kernel.cache_dir%/translations"
         public: true
     WizaplaceFrontBundle\Command\GenerateSitemapCommand:
+        arguments:
+            $sitemap: '@sitemap_rich'
         public: true
     WizaplaceFrontBundle\Service\AuthenticationService:
         public: true

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -29,8 +29,6 @@ services:
             $cacheDir: "%kernel.cache_dir%/translations"
         public: true
     WizaplaceFrontBundle\Command\GenerateSitemapCommand:
-        arguments:
-            $sitemap: '@sitemap_rich'
         public: true
     WizaplaceFrontBundle\Service\AuthenticationService:
         public: true

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -29,8 +29,6 @@ services:
             $cacheDir: "%kernel.cache_dir%/translations"
         public: true
     WizaplaceFrontBundle\Command\GenerateSitemapCommand:
-        arguments:
-            $locales: '%locales%'
         public: true
     WizaplaceFrontBundle\Service\AuthenticationService:
         public: true

--- a/src/Resources/config/config_sitemap.yml
+++ b/src/Resources/config/config_sitemap.yml
@@ -5,8 +5,6 @@ services:
         arguments:
             $defaultLocale: '%kernel.default_locale%'
             $locales: '%locales%'
-        tags:
-            - { name: sitemap.provider }
 
     sitemap_gz_dumper:
         class: SitemapGenerator\Dumper\GzFileDumper
@@ -15,8 +13,12 @@ services:
     sitemap_richxml_formatter:
         class: SitemapGenerator\Formatter\RichXmlFormatter
 
-    sitemap_rich:
+    sitemap:
         class: SitemapGenerator\Sitemap\Sitemap
         arguments:
             - "@sitemap_gz_dumper"
             - "@sitemap_richxml_formatter"
+        calls:
+            - method: addProvider
+              arguments:
+                  - '@WizaplaceFrontBundle\Service\SitemapGenerator'

--- a/src/Resources/config/config_sitemap.yml
+++ b/src/Resources/config/config_sitemap.yml
@@ -15,7 +15,7 @@ services:
     sitemap_richxml_formatter:
         class: SitemapGenerator\Formatter\RichXmlFormatter
 
-    sitemap:
+    sitemap_rich:
         class: SitemapGenerator\Sitemap\Sitemap
         arguments:
             - "@sitemap_gz_dumper"

--- a/src/Resources/config/config_sitemap.yml
+++ b/src/Resources/config/config_sitemap.yml
@@ -8,6 +8,10 @@ services:
         tags:
             - { name: sitemap.provider }
 
+    sitemap_gz_dumper:
+        class: SitemapGenerator\Dumper\GzFileDumper
+        arguments: [ "%kernel.root_dir%/../web/sitemap.xml.gz" ]
+
     sitemap_richxml_formatter:
         class: SitemapGenerator\Formatter\RichXmlFormatter
 
@@ -16,6 +20,3 @@ services:
         arguments:
             - "@sitemap_gz_dumper"
             - "@sitemap_richxml_formatter"
-            - "%sitemap.config.base_host%"
-            - "%sitemap.config.base_host_sitemap%"
-            - "%sitemap.config.limit%"

--- a/src/Resources/config/config_sitemap.yml
+++ b/src/Resources/config/config_sitemap.yml
@@ -2,5 +2,8 @@ services:
     WizaplaceFrontBundle\Service\SitemapGenerator:
         public: false
         autowire: true
+        arguments:
+            $defaultLocale: '%kernel.default_locale%'
+            $locales: '%locales%'
         tags:
             - { name: sitemap.provider }

--- a/src/Resources/config/config_sitemap.yml
+++ b/src/Resources/config/config_sitemap.yml
@@ -13,8 +13,7 @@ services:
     sitemap_richxml_formatter:
         class: SitemapGenerator\Formatter\RichXmlFormatter
 
-    sitemap:
-        class: SitemapGenerator\Sitemap\Sitemap
+    SitemapGenerator\Sitemap\Sitemap:
         arguments:
             - "@sitemap_gz_dumper"
             - "@sitemap_richxml_formatter"

--- a/src/Resources/config/config_sitemap.yml
+++ b/src/Resources/config/config_sitemap.yml
@@ -7,3 +7,15 @@ services:
             $locales: '%locales%'
         tags:
             - { name: sitemap.provider }
+
+    sitemap_richxml_formatter:
+        class: SitemapGenerator\Formatter\RichXmlFormatter
+
+    sitemap:
+        class: SitemapGenerator\Sitemap\Sitemap
+        arguments:
+            - "@sitemap_gz_dumper"
+            - "@sitemap_richxml_formatter"
+            - "%sitemap.config.base_host%"
+            - "%sitemap.config.base_host_sitemap%"
+            - "%sitemap.config.limit%"

--- a/src/Service/SitemapGenerator.php
+++ b/src/Service/SitemapGenerator.php
@@ -9,7 +9,7 @@ namespace WizaplaceFrontBundle\Service;
 
 use Dpn\XmlSitemapBundle\Sitemap\Entry;
 use Dpn\XmlSitemapBundle\Sitemap\GeneratorInterface;
-use SitemapGenerator\Entity\Url;
+use SitemapGenerator\Entity\RichUrl;
 use SitemapGenerator\Provider\ProviderInterface;
 use SitemapGenerator\Sitemap\Sitemap;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -28,10 +28,24 @@ class SitemapGenerator implements ProviderInterface
     /** @var RouterInterface */
     private $router;
 
-    public function __construct(SeoService $seoService, RouterInterface $router)
+    /** @var string */
+    private $defaultLocale;
+
+    /** @var string[] */
+    private $alternateLocales;
+
+    public function __construct(SeoService $seoService, RouterInterface $router, string $defaultLocale, array $locales)
     {
         $this->seoService = $seoService;
         $this->router = $router;
+        $this->defaultLocale = $defaultLocale;
+
+        // On supprime la locale par défaut des langues alternatives
+        if (false !== $key = array_search($defaultLocale, $locales)) {
+            unset($locales[$key]);
+        }
+
+        $this->alternateLocales = $locales;
     }
 
     /**
@@ -55,8 +69,19 @@ class SitemapGenerator implements ProviderInterface
         $routeCollection = $this->router->getRouteCollection();
         foreach ($routeCollection as $routeName => $route) {
             if ($route->getOption(self::SITEMAP_ROUTE_OPTION_NAME)) {
-                $url = new Url();
-                $url->setLoc($this->router->generate($routeName, [], UrlGeneratorInterface::ABSOLUTE_PATH));
+                $url = new RichUrl();
+                $parameters = [];
+
+                if ($route->hasRequirement('_locale')) {
+                    $parameters['_locale'] = $this->defaultLocale;
+                }
+
+                $url->setLoc($this->router->generate($routeName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+
+                foreach ($this->alternateLocales as $locale) {
+                    $url->addAlternateUrl($locale, $this->router->generate($routeName, ['_locale' => $locale], UrlGeneratorInterface::ABSOLUTE_PATH));
+                }
+
                 $sitemap->add($url);
             }
         }
@@ -70,22 +95,22 @@ class SitemapGenerator implements ProviderInterface
      */
     private function populateDynamicEntries(Sitemap $sitemap): void
     {
-        $cmsPageRoute = 'cms_page';
-        $cmsPageRouteExists = $this->router->getRouteCollection()->get($cmsPageRoute) !== null;
+        $cmsPageRouteName = 'cms_page';
+        $cmsPageRoute = $this->router->getRouteCollection()->get($cmsPageRouteName);
 
-        $categoryRoute = 'category';
-        $categoryRouteExists = $this->router->getRouteCollection()->get($categoryRoute) !== null;
+        $categoryRouteName = 'category';
+        $categoryRoute = $this->router->getRouteCollection()->get($categoryRouteName);
 
-        $attrVariantRoute = 'attribute_variant';
-        $attrVariantRouteExists = $this->router->getRouteCollection()->get($attrVariantRoute) !== null;
+        $attrVariantRouteName = 'attribute_variant';
+        $attrVariantRoute = $this->router->getRouteCollection()->get($attrVariantRouteName);
 
-        $companyRoute = 'company';
-        $companyRouteExists = $this->router->getRouteCollection()->get($companyRoute) !== null;
+        $companyRouteName = 'company';
+        $companyRoute = $this->router->getRouteCollection()->get($companyRouteName);
 
-        $productRoute = 'product';
-        $productRouteExists = $this->router->getRouteCollection()->get($productRoute) !== null;
+        $productRouteName = 'product';
+        $productRoute = $this->router->getRouteCollection()->get($productRouteName);
 
-        if (!$cmsPageRouteExists && !$categoryRouteExists && !$attrVariantRouteExists && !$companyRouteExists && !$productRouteExists) {
+        if (is_null($cmsPageRoute) && is_null($categoryRoute) && is_null($attrVariantRoute) && is_null($companyRoute) && is_null($productRoute)) {
             return;
         }
 
@@ -93,26 +118,74 @@ class SitemapGenerator implements ProviderInterface
         foreach ($slugsCatalog as $slugCatalogItem) {
             $type = $slugCatalogItem->getTarget()->getObjectType();
 
-            $url = new Url();
+            $url = new RichUrl();
 
-            if ($cmsPageRouteExists && $type->equals(SlugTargetType::CMS_PAGE())) {
-                $url->setLoc($this->router->generate($cmsPageRoute, ['slug' => $slugCatalogItem->getSlug()], UrlGeneratorInterface::ABSOLUTE_PATH));
-            } elseif ($categoryRouteExists && $type->equals(SlugTargetType::CATEGORY())) {
-                $url->setLoc($this->router->generate($categoryRoute, ['slug' => $slugCatalogItem->getSlug()], UrlGeneratorInterface::ABSOLUTE_PATH));
-            } elseif ($attrVariantRouteExists && $type->equals(SlugTargetType::ATTRIBUTE_VARIANT())) {
-                $url->setLoc($this->router->generate($attrVariantRoute, ['slug' => $slugCatalogItem->getSlug()], UrlGeneratorInterface::ABSOLUTE_PATH));
-            } elseif ($companyRouteExists && $type->equals(SlugTargetType::COMPANY())) {
-                $url->setLoc($this->router->generate($companyRoute, ['slug' => $slugCatalogItem->getSlug()], UrlGeneratorInterface::ABSOLUTE_PATH));
-            } elseif ($productRouteExists && $type->equals(SlugTargetType::PRODUCT())) {
-                $url->setLoc($this->router->generate($productRoute, [
-                    'slug' => $slugCatalogItem->getSlug(),
-                    'categoryPath' => join(
-                        '/',
-                        array_map(function (SlugCatalogItem $data): string {
-                            return $data->getSlug();
-                        }, $slugCatalogItem->getCategoryPath())
-                    ),
-                ], UrlGeneratorInterface::ABSOLUTE_PATH));
+            $parameters = [
+                'slug' => $slugCatalogItem->getSlug(),
+            ];
+
+            if ($cmsPageRoute && $type->equals(SlugTargetType::CMS_PAGE())) {
+                if ($cmsPageRoute->hasRequirement('_locale')) {
+                    $parameters['_locale'] = $this->defaultLocale;
+                }
+
+                $url->setLoc($this->router->generate($cmsPageRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+
+                foreach ($this->alternateLocales as $locale) {
+                    $parameters['_locale'] = $locale;
+                    $url->addAlternateUrl($locale, $this->router->generate($cmsPageRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                }
+            } elseif ($categoryRoute && $type->equals(SlugTargetType::CATEGORY())) {
+                if ($categoryRoute->hasRequirement('_locale')) {
+                    $parameters['_locale'] = $this->defaultLocale;
+                }
+
+                $url->setLoc($this->router->generate($categoryRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+
+                foreach ($this->alternateLocales as $locale) {
+                    $parameters['_locale'] = $locale;
+                    $url->addAlternateUrl($locale, $this->router->generate($categoryRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                }
+            } elseif ($attrVariantRoute && $type->equals(SlugTargetType::ATTRIBUTE_VARIANT())) {
+                if ($attrVariantRoute->hasRequirement('_locale')) {
+                    $parameters['_locale'] = $this->defaultLocale;
+                }
+
+                $url->setLoc($this->router->generate($attrVariantRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+
+                foreach ($this->alternateLocales as $locale) {
+                    $parameters['_locale'] = $locale;
+                    $url->addAlternateUrl($locale, $this->router->generate($attrVariantRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                }
+            } elseif ($companyRoute && $type->equals(SlugTargetType::COMPANY())) {
+                if ($companyRoute->hasRequirement('_locale')) {
+                    $parameters['_locale'] = $this->defaultLocale;
+                }
+
+                $url->setLoc($this->router->generate($companyRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+
+                foreach ($this->alternateLocales as $locale) {
+                    $parameters['_locale'] = $locale;
+                    $url->addAlternateUrl($locale, $this->router->generate($companyRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                }
+            } elseif ($productRoute && $type->equals(SlugTargetType::PRODUCT())) {
+                if ($productRoute->hasRequirement('_locale')) {
+                    $parameters['_locale'] = $this->defaultLocale;
+                }
+
+                $parameters['categoryPath'] = join(
+                    '/',
+                    array_map(function (SlugCatalogItem $data): string {
+                        return $data->getSlug();
+                    }, $slugCatalogItem->getCategoryPath())
+                );
+
+                $url->setLoc($this->router->generate($productRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+
+                foreach ($this->alternateLocales as $locale) {
+                    $parameters['_locale'] = $locale;
+                    $url->addAlternateUrl($locale, $this->router->generate($productRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                }
             } else {
                 continue;
             }

--- a/src/Service/SitemapGenerator.php
+++ b/src/Service/SitemapGenerator.php
@@ -76,10 +76,10 @@ class SitemapGenerator implements ProviderInterface
                     $parameters['_locale'] = $this->defaultLocale;
                 }
 
-                $url->setLoc($this->router->generate($routeName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                $url->setLoc($this->router->generate($routeName, $parameters, UrlGeneratorInterface::ABSOLUTE_URL));
 
                 foreach ($this->alternateLocales as $locale) {
-                    $url->addAlternateUrl($locale, $this->router->generate($routeName, ['_locale' => $locale], UrlGeneratorInterface::ABSOLUTE_PATH));
+                    $url->addAlternateUrl($locale, $this->router->generate($routeName, ['_locale' => $locale], UrlGeneratorInterface::ABSOLUTE_URL));
                 }
 
                 $sitemap->add($url);
@@ -129,44 +129,44 @@ class SitemapGenerator implements ProviderInterface
                     $parameters['_locale'] = $this->defaultLocale;
                 }
 
-                $url->setLoc($this->router->generate($cmsPageRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                $url->setLoc($this->router->generate($cmsPageRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_URL));
 
                 foreach ($this->alternateLocales as $locale) {
                     $parameters['_locale'] = $locale;
-                    $url->addAlternateUrl($locale, $this->router->generate($cmsPageRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                    $url->addAlternateUrl($locale, $this->router->generate($cmsPageRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_URL));
                 }
             } elseif ($categoryRoute && $type->equals(SlugTargetType::CATEGORY())) {
                 if ($categoryRoute->hasRequirement('_locale')) {
                     $parameters['_locale'] = $this->defaultLocale;
                 }
 
-                $url->setLoc($this->router->generate($categoryRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                $url->setLoc($this->router->generate($categoryRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_URL));
 
                 foreach ($this->alternateLocales as $locale) {
                     $parameters['_locale'] = $locale;
-                    $url->addAlternateUrl($locale, $this->router->generate($categoryRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                    $url->addAlternateUrl($locale, $this->router->generate($categoryRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_URL));
                 }
             } elseif ($attrVariantRoute && $type->equals(SlugTargetType::ATTRIBUTE_VARIANT())) {
                 if ($attrVariantRoute->hasRequirement('_locale')) {
                     $parameters['_locale'] = $this->defaultLocale;
                 }
 
-                $url->setLoc($this->router->generate($attrVariantRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                $url->setLoc($this->router->generate($attrVariantRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_URL));
 
                 foreach ($this->alternateLocales as $locale) {
                     $parameters['_locale'] = $locale;
-                    $url->addAlternateUrl($locale, $this->router->generate($attrVariantRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                    $url->addAlternateUrl($locale, $this->router->generate($attrVariantRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_URL));
                 }
             } elseif ($companyRoute && $type->equals(SlugTargetType::COMPANY())) {
                 if ($companyRoute->hasRequirement('_locale')) {
                     $parameters['_locale'] = $this->defaultLocale;
                 }
 
-                $url->setLoc($this->router->generate($companyRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                $url->setLoc($this->router->generate($companyRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_URL));
 
                 foreach ($this->alternateLocales as $locale) {
                     $parameters['_locale'] = $locale;
-                    $url->addAlternateUrl($locale, $this->router->generate($companyRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                    $url->addAlternateUrl($locale, $this->router->generate($companyRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_URL));
                 }
             } elseif ($productRoute && $type->equals(SlugTargetType::PRODUCT())) {
                 if ($productRoute->hasRequirement('_locale')) {
@@ -180,11 +180,11 @@ class SitemapGenerator implements ProviderInterface
                     }, $slugCatalogItem->getCategoryPath())
                 );
 
-                $url->setLoc($this->router->generate($productRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                $url->setLoc($this->router->generate($productRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_URL));
 
                 foreach ($this->alternateLocales as $locale) {
                     $parameters['_locale'] = $locale;
-                    $url->addAlternateUrl($locale, $this->router->generate($productRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH));
+                    $url->addAlternateUrl($locale, $this->router->generate($productRouteName, $parameters, UrlGeneratorInterface::ABSOLUTE_URL));
                 }
             } else {
                 continue;

--- a/tests/Service/SitemapGeneratorTest.php
+++ b/tests/Service/SitemapGeneratorTest.php
@@ -30,11 +30,11 @@ class SitemapGeneratorTest extends BundleTestCase
             return $invocation->getParameters()[0]->getLoc();
         }, $spy->getInvocations());
 
-        self::assertContains('/', $urls); // static URL
-        self::assertContains('/a/adidas', $urls); // attribute variant URL
-        self::assertContains('/p/it/headsets/casque-corsair-gaming', $urls); // product URL
-        self::assertContains('/c/categorie-principale', $urls); // category URL
-        self::assertContains('/v/acme', $urls); // company URL
-        self::assertContains('/faq', $urls); // CMS page URL
+        self::assertContains('http://localhost/', $urls); // static URL
+        self::assertContains('http://localhost/a/adidas', $urls); // attribute variant URL
+        self::assertContains('http://localhost/p/it/headsets/casque-corsair-gaming', $urls); // product URL
+        self::assertContains('http://localhost/c/categorie-principale', $urls); // category URL
+        self::assertContains('http://localhost/v/acme', $urls); // company URL
+        self::assertContains('http://localhost/faq', $urls); // CMS page URL
     }
 }


### PR DESCRIPTION
## Checklist

- [x] Changelog updated

Basé sur les recommandations de Google pour un sitemap multilingue https://support.google.com/webmasters/answer/189077

Si la route a besoin du paramètre `_locale` alors on lui injecte. De plus on va boucler sur les langues alternatives pour générer toutes les URLs.