### PR TITLE
WIZ-4130 - Fix empty number separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
 
 </details>
 
+## 0.5.7
+
+### Bugfixes
+
+- Default English translation for number separators
+- Use French separators if their translation is not found
+
 ## 0.5.6
 
 ### Bugfixes

--- a/src/Resources/translations/messages.en.json
+++ b/src/Resources/translations/messages.en.json
@@ -1,0 +1,4 @@
+{
+  "price.decimal-delimiter": ".",
+  "price.thousands-delimiter": ","
+}

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -117,8 +117,8 @@ class AppExtension extends \Twig_Extension
 
     public function formatPrice(float $price): string
     {
-        $decimalSeparator = $this->translator->trans('price.decimal-delimiter');
-        $thousandsSeparator = $this->translator->trans('price.thousands-delimiter');
+        $decimalSeparator = $this->translator->trans('price.decimal-delimiter') ?: ',';
+        $thousandsSeparator = $this->translator->trans('price.thousands-delimiter') ?: ' ';
         $currency = $this->translator->trans('price.currency');
 
         $formattedPrice = number_format($price, 2, $decimalSeparator, $thousandsSeparator);


### PR DESCRIPTION
[Ticket JIRA](https://wizaplace.atlassian.net/browse/WIZ-4130)

   - Adds a default EN translation
   - Use French separator as default if the current locale's separators are not defined

**Attention**: il faudra bien penser à tagger une nouvelle version.

## Checklist

- [x] Changelog updated
