### PR TITLE
WIZ-5390 Translations commands : additionnal logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### New features
 
-- Debug logs for translations commands (ex.: `bin/console wizaplace:translations:push -vvvv`)
+- Debug logs for translations commands (ex.: `bin/console wizaplace:translations:push -vvv`)
 
 ## 0.5.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 
 </details>
 
+## Next version
+
+### New features
+
+- Debug logs for translations commands (ex.: `bin/console wizaplace:translations:push -vvvv`)
+
 ## 0.5.7
 
 ### Bugfixes

--- a/src/Command/PullTranslationsCommand.php
+++ b/src/Command/PullTranslationsCommand.php
@@ -7,13 +7,14 @@ declare(strict_types=1);
 
 namespace WizaplaceFrontBundle\Command;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Wizaplace\SDK\Translation\TranslationService;
-use WizaplaceFrontBundle\Service\AuthenticationService;
 use Symfony\Component\Finder\Finder;
+use WizaplaceFrontBundle\Service\AuthenticationService;
+use Wizaplace\SDK\Translation\TranslationService;
 
 class PullTranslationsCommand extends Command
 {
@@ -21,6 +22,7 @@ class PullTranslationsCommand extends Command
      * hash('sha256', '');
      */
     const EMPTY_HASH = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+    private const LOGGER_HEADER = 'Translations:Pull';
 
     /** @var TranslationService */
     private $translationService;
@@ -34,21 +36,26 @@ class PullTranslationsCommand extends Command
     /** @var string */
     private $translationsDir;
 
-        /** @var string */
+    /** @var string */
     private $cacheDir;
+
+    /** @var LoggerInterface */
+    private $logger;
 
     public function __construct(
         TranslationService $translationService,
         AuthenticationService $authenticationService,
         array $locales,
-        $translationsDir,
-        $cacheDir
+        string $translationsDir,
+        string $cacheDir,
+        LoggerInterface $logger
     ) {
         $this->translationService = $translationService;
         $this->authenticationService = $authenticationService;
         $this->locales = $locales;
         $this->translationsDir = $translationsDir;
         $this->cacheDir = $cacheDir;
+        $this->logger = $logger;
 
         parent::__construct();
     }
@@ -69,11 +76,14 @@ class PullTranslationsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new SymfonyStyle($input, $output);
-        array_walk($this->locales, function (string $locale) use ($io) : void {
-            $io->section("Processing locale '$locale'...");
-            $this->executeLocale($locale);
-            $io->success("'$locale' locale successfully pulled");
-        });
+        array_walk(
+            $this->locales,
+            function (string $locale) use ($io) : void {
+                $io->section("Processing locale '$locale'...");
+                $this->executeLocale($locale);
+                $io->success("'$locale' locale successfully pulled");
+            }
+        );
     }
 
     private function executeLocale(string $locale): void
@@ -87,17 +97,45 @@ class PullTranslationsCommand extends Command
             $oldHash = hash_file('sha256', $catalogFilePath);
         }
 
-        file_put_contents($catalogFilePath, $xliffCatalog->getContents());
+
+        $xliffCatalogContent = $xliffCatalog->getContents();
+
+        $this->logger->debug(
+            self::LOGGER_HEADER,
+            [
+                'catalogFilePath' => $catalogFilePath,
+                'xliff catalog' => $xliffCatalogContent,
+            ]
+        );
+
+        file_put_contents($catalogFilePath, $xliffCatalogContent);
         $newHash = hash_file('sha256', $catalogFilePath);
 
         // Si le nouveau contenu est identique à l'ancien, pas besoin de flush le cache
         if (hash_equals($oldHash, $newHash)) {
+            $this->logger->debug(
+                self::LOGGER_HEADER,
+                [
+                    'catalogFilePath' => $catalogFilePath,
+                    'flush' => "xliff hash: old - $oldHash === new - $newHash , no need to flush"
+                ]
+            );
+
             return;
         }
 
         if (!file_exists($this->cacheDir)) {
+            $this->logger->debug(
+                self::LOGGER_HEADER,
+                [
+                    'catalogFilePath' => $catalogFilePath,
+                    'flush' => 'cache dir not exist, no need to flush',
+                ]
+            );
+
             return;
         }
+
         $finder = new Finder();
         $finder
             ->files()
@@ -107,7 +145,15 @@ class PullTranslationsCommand extends Command
 
         // On parcours tous les fichiers qui concernent la locale et on les supprime
         foreach ($finder as $file) {
-            unlink($file->getRealPath());
+            $deleted = unlink($file->getRealPath());
+
+            $this->logger->debug(
+                self::LOGGER_HEADER,
+                [
+                    'file' => $file,
+                    'deleted' => $deleted,
+                ]
+            );
         }
     }
 }

--- a/src/Command/PullTranslationsCommand.php
+++ b/src/Command/PullTranslationsCommand.php
@@ -13,13 +13,13 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\Finder;
-use WizaplaceFrontBundle\Service\AuthenticationService;
 use Wizaplace\SDK\Translation\TranslationService;
+use WizaplaceFrontBundle\Service\AuthenticationService;
 
 class PullTranslationsCommand extends Command
 {
     /**
-     * hash('sha256', '');
+     * hash('sha256', '');.
      */
     const EMPTY_HASH = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
     private const LOGGER_HEADER = 'Translations:Pull';
@@ -78,7 +78,7 @@ class PullTranslationsCommand extends Command
         $io = new SymfonyStyle($input, $output);
         array_walk(
             $this->locales,
-            function (string $locale) use ($io) : void {
+            function (string $locale) use ($io): void {
                 $io->section("Processing locale '$locale'...");
                 $this->executeLocale($locale);
                 $io->success("'$locale' locale successfully pulled");
@@ -96,7 +96,6 @@ class PullTranslationsCommand extends Command
         if (file_exists($catalogFilePath)) {
             $oldHash = hash_file('sha256', $catalogFilePath);
         }
-
 
         $xliffCatalogContent = $xliffCatalog->getContents();
 
@@ -117,7 +116,7 @@ class PullTranslationsCommand extends Command
                 self::LOGGER_HEADER,
                 [
                     'catalogFilePath' => $catalogFilePath,
-                    'flush' => "xliff hash: old - $oldHash === new - $newHash , no need to flush"
+                    'flush' => "xliff hash: old - $oldHash === new - $newHash , no need to flush",
                 ]
             );
 

--- a/src/Command/PushTranslationsCommand.php
+++ b/src/Command/PushTranslationsCommand.php
@@ -15,8 +15,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Translation\Dumper\XliffFileDumper;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\TranslatorBagInterface;
-use WizaplaceFrontBundle\Service\AuthenticationService;
 use Wizaplace\SDK\Translation\TranslationService;
+use WizaplaceFrontBundle\Service\AuthenticationService;
 
 class PushTranslationsCommand extends Command
 {
@@ -105,9 +105,11 @@ class PushTranslationsCommand extends Command
         $catalog = $this->translatorBag->getCatalogue($locale);
 
         // Format it as xliff
-        $xliffCatalog = $this->translationDumper->formatCatalogue($catalog, self::CATALOG_DOMAIN, [
-            'default_locale' => $this->defaultLocale,
-            ]);
+        $xliffCatalog = $this->translationDumper->formatCatalogue(
+            $catalog,
+            self::CATALOG_DOMAIN,
+            ['default_locale' => $this->defaultLocale]
+        );
 
         $this->logger->debug(
             self::LOGGER_HEADER,


### PR DESCRIPTION
[Ticket JIRA](https://wizaplace.atlassian.net/browse/WIZ-5390)

Afin d'investiguer sur le https://wizaplace.atlassian.net/browse/WIZ-5200

Des logs de debug additionnels pour les commande `bin/console -vvv wizaplace:translations:(push|pull)` à jouer sur les sandbox afin de nous aidez à déterminer la cause du bug sur les traductions OVH et Blissports.
 
## Checklist

- [ ] Changelog updated
