### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @wizaplace/sdk
+* @wizaplace/team-sdk


### PR DESCRIPTION
[Ticket JIRA](https://wizaplace.atlassian.net/browse/IN-2015)

## Détail de la demande

Les CODEOWNERS de nos repos Github doivent être mis à jour pour respecter la nouvelle organisation des équipes Github, et en particulier leur renommage (cf ticket Jira).

## Détail des modifications

Update des noms d'équipes dans le fichier CODEOWNERS
